### PR TITLE
Fix of issue with realtime reset

### DIFF
--- a/src/components/cookie-builder.vue
+++ b/src/components/cookie-builder.vue
@@ -14,10 +14,12 @@ import CookieToolbar from './cookie-toolbar.vue'
 
 const savedCookie = localStorage.getItem('saved-cookie')
 
-let cookie = reactive<Cookie>(savedCookie ? JSON.parse(savedCookie) : DEFAULT_COOKIE)
+const cookie = reactive<Cookie>(savedCookie ? JSON.parse(savedCookie) : DEFAULT_COOKIE)
 
 function updateCookie(newCookie: Cookie) {
-  Object.assign(cookie, newCookie)
+  Object.keys(newCookie).forEach(key => {
+    cookie[key as keyof Cookie] = newCookie[key as keyof Cookie]
+  })
 }
 </script>
 

--- a/src/components/cookie-builder.vue
+++ b/src/components/cookie-builder.vue
@@ -18,7 +18,7 @@ const cookie = reactive<Cookie>(savedCookie ? JSON.parse(savedCookie) : DEFAULT_
 
 function updateCookie(newCookie: Cookie) {
   Object.keys(newCookie).forEach(key => {
-    cookie[key as keyof Cookie] = newCookie[key as keyof Cookie]
+    (cookie[key as keyof Cookie] as any) = newCookie[key as keyof Cookie]
   })
 }
 </script>

--- a/src/components/cookie-toolbar.vue
+++ b/src/components/cookie-toolbar.vue
@@ -37,7 +37,10 @@ function resetCookie() {
     acceptLabel: 'Reset',
     rejectClass: 'p-button-secondary p-button-outlined',
     acceptClass: 'p-button-danger',
-    accept: () => emit('update:cookie', DEFAULT_COOKIE)
+    accept: () => {
+      const resetCookie = JSON.parse(JSON.stringify(DEFAULT_COOKIE))
+      emit('update:cookie', resetCookie)
+    }
   })
 }
 


### PR DESCRIPTION
When cookie is not saved, the reset button doesnt respond.

This fix makes the reset button also clear the form inputs.

Issue mentioned by #1 